### PR TITLE
Get favorites

### DIFF
--- a/helpers/favorites.js
+++ b/helpers/favorites.js
@@ -28,7 +28,18 @@ function remove(location, id) {
   });
 }
 
+function retrieve(id) {
+  return database('favorites').where({user_id: id})
+  .then(favorites => favorites)
+  .catch(error => {
+    return {
+      message: { error: error },
+      status: 500 }
+  });
+}
+
 module.exports = {
   create: create,
-  remove: remove
+  remove: remove,
+  retrieve: retrieve
 }

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -22,7 +22,7 @@ router.get('/', (req, res) => {
           Promise.all(allPromises).then(data => {
             return res.status(200).send(
               data.map((json, index) => {
-              return {location: favsArray[index].location, currently: current(json)}
+                return {location: favsArray[index].location, currently: current(json)}
               })
             )
           })


### PR DESCRIPTION
This closes #8 
Add route: Using multiple fetch calls in `/api/v1/favorites GET` route--organizes calls into promise objects that can then be used to tie back to the index position they were called. 

Add helper method: by putting in a `user id` you can retrieve all  favorited locations by that user

@ap2322
@lrs8810